### PR TITLE
corrected STUB_GPU macro to enable it to compile in CPU only mode

### DIFF
--- a/src/caffe/layers/duplicate_layer.cpp
+++ b/src/caffe/layers/duplicate_layer.cpp
@@ -70,7 +70,7 @@ void DuplicateLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
 }
 
 #ifdef CPU_ONLY
-STUB_GPU(DeconvTransLayer);
+STUB_GPU(DuplicateLayer);
 #endif
 
 INSTANTIATE_CLASS(DuplicateLayer);


### PR DESCRIPTION
The build was failing for this repository in CPU only mode, so had to make the change mentioned in the PR to go ahead with the compilatiom
files changed: src/caffe/layers/duplicate_layer.cpp
